### PR TITLE
asyncを使っているのに生かしてなかったのを修正。型を追加

### DIFF
--- a/app/controllers/accessLogsController.ts
+++ b/app/controllers/accessLogsController.ts
@@ -58,7 +58,7 @@ async function listAccessLogs (req: Request, res: Response) {
     }
     res.status(200).json(json)
   } catch (err) {
-    console.error(err)
+    console.error('[!] DB Error:', err)
     res.status(500).json({ message: err.message || 'internal server error' })
   }
 }

--- a/app/controllers/inRoomUsersController.ts
+++ b/app/controllers/inRoomUsersController.ts
@@ -13,7 +13,7 @@ async function getUser (req: Request, res: Response) {
       res.status(200).json(toBeSent)
     }
   } catch (err) {
-    console.error('[!] Error', err)
+    console.error('[!] DB Error:', err)
     res.status(500).json({ message: err.message || 'internal server error' })
   }
 }
@@ -26,7 +26,7 @@ async function listUsers (_req: Request, res: Response) {
     }
     res.status(200).json(toBeSent)
   } catch (err) {
-    console.error('[!] Error', err)
+    console.error('[!] DB Error:', err)
     res.status(500).json({ message: err.message || 'internal server error' })
   }
 }

--- a/app/controllers/inRoomUsersController.ts
+++ b/app/controllers/inRoomUsersController.ts
@@ -2,10 +2,8 @@ import { Request, Response } from 'express'
 import * as table from '../models/inRoomUsersModel'
 
 async function getUser (req: Request, res: Response) {
-  const [user, err] = await table.getUser(parseInt(req.params.user_id))
-  if (err) {
-    res.status(500).json({ message: err.message || 'internal server error' })
-  } else {
+  try {
+    const user = await table.getUser(parseInt(req.params.user_id))
     if (!user) {
       res.status(204).send() // 指定された人が在室していなかったとき
     } else {
@@ -14,18 +12,22 @@ async function getUser (req: Request, res: Response) {
       }
       res.status(200).json(toBeSent)
     }
+  } catch (err) {
+    console.error('[!] Error', err)
+    res.status(500).json({ message: err.message || 'internal server error' })
   }
 }
 
 async function listUsers (_req: Request, res: Response) {
-  const [users, err] = await table.listUsers()
-  if (err) {
-    res.status(500).json({ message: err.message || 'internal server error' })
-  } else {
+  try {
+    const users = await table.listUsers()
     const toBeSent = {
       data: users
     }
     res.status(200).json(toBeSent)
+  } catch (err) {
+    console.error('[!] Error', err)
+    res.status(500).json({ message: err.message || 'internal server error' })
   }
 }
 

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -88,7 +88,7 @@ async function handleReaderInput (req: Request, res: Response) {
     await mysql.beginTransaction()
     if (user) {
       // 退室
-      await logsTable.createAccessLog(user.user_id, String(user.entered_at))
+      await logsTable.createAccessLog(user.user_id, user.entered_at)
       await roomTable.deleteUser(user.user_id)
     } else {
       // 入室

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -97,7 +97,7 @@ async function handleReaderInput (req: Request, res: Response) {
     await mysql.commit()
   } catch (err) {
     playWav('error')
-    console.error('[!] Error:', err)
+    console.error('[!] DB Error:', err)
     await mysql.rollback()
     res.status(500).json({ message: err.message || 'internal server error' })
     return

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -88,8 +88,8 @@ async function handleReaderInput (req: Request, res: Response) {
     await mysql.beginTransaction()
     if (user) {
       // 退室
-      await logsTable.createAccessLog((user as any).user_id, (user as any).entered_at)
-      await roomTable.deleteUser((user as any).user_id)
+      await logsTable.createAccessLog(user.user_id, String(user.entered_at))
+      await roomTable.deleteUser(user.user_id)
     } else {
       // 入室
       await roomTable.createUser(receivedUserId)

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -96,11 +96,7 @@ async function handleReaderInput (req: Request, res: Response) {
     await mysql.beginTransaction()
     if (isExit) {
       // 退室
-      const [_caResult, caErr] = await logsTable.createAccessLog(user.user_id, user.entered_at)
-      // エラーがnullでなかったらthrowする
-      if (caErr) {
-        throw caErr
-      }
+      await logsTable.createAccessLog(user.user_id, user.entered_at)
       const [_duResult, duErr] = await roomTable.deleteUser(user.user_id)
       if (duErr) {
         throw duErr

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -48,9 +48,7 @@ async function handleReaderInput (req: Request, res: Response) {
 
   // statusが適切かチェック
   if (!isValidStatus(readerStatus)) {
-    res.status(400).json({
-      message: 'Invalid status in body'
-    })
+    res.status(400).json({ message: 'Invalid status in body' })
     console.error('[!] Received a request including invalid status')
     return
   }
@@ -59,9 +57,7 @@ async function handleReaderInput (req: Request, res: Response) {
     case Status.SUCCESS:
       // ちゃんとしたIDが来ているかチェック
       if (!Number.isInteger(receivedUserId)) {
-        res.status(400).json({
-          message: 'Invalid user_id in body'
-        })
+        res.status(400).json({ message: 'Invalid user_id in body' })
         console.error('[!] Received a request including invalid user_id')
         return
       }
@@ -84,29 +80,19 @@ async function handleReaderInput (req: Request, res: Response) {
   }
 
   // 入室or退室処理
-  const [user, err] = await roomTable.getUser(receivedUserId)
-  if (err) {
-    console.error('[!] Error:', err)
-    res.status(500).json({ message: err.message || 'internal server error' })
-    return
-  }
-
-  const isExit = !!user
+  let isExit = false
   try {
+    const user = await roomTable.getUser(receivedUserId)
+    isExit = !!user
+
     await mysql.beginTransaction()
-    if (isExit) {
+    if (user) {
       // 退室
-      await logsTable.createAccessLog(user.user_id, user.entered_at)
-      const [_duResult, duErr] = await roomTable.deleteUser(user.user_id)
-      if (duErr) {
-        throw duErr
-      }
+      await logsTable.createAccessLog((user as any).user_id, (user as any).entered_at)
+      await roomTable.deleteUser((user as any).user_id)
     } else {
       // 入室
-      const [_cuResult, cuErr] = await roomTable.createUser(receivedUserId)
-      if (cuErr) {
-        throw cuErr
-      }
+      await roomTable.createUser(receivedUserId)
     }
     await mysql.commit()
   } catch (err) {

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -3,11 +3,7 @@ import { EventEmitter } from 'events'
 import { Request, Response } from 'express'
 import * as roomTable from '../models/inRoomUsersModel'
 
-type NamedInRoomUser = {
-  'user_id': number,
-  'user_name'?: string | null,
-  'entered_at': Date
-}
+type NamedInRoomUser = roomTable.InRoomUser & { 'user_name'?: string | null }
 
 /**
  * SSEの送り先リスト

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -3,21 +3,10 @@ import { EventEmitter } from 'events'
 import { Request, Response } from 'express'
 import * as roomTable from '../models/inRoomUsersModel'
 
-// TODO あとでmodelsかどこかのファイルに移動する
-/**
- * クライアントに返すデータの構造のもと
- */
-interface InRoomUser {
+type NamedInRoomUser = {
   'user_id': number,
+  'user_name'?: string | null,
   'entered_at': Date
-}
-
-// TODO あとでmodelsかどこかのファイルに移動する
-/**
- * クライアントに返すデータの構造
- */
-interface NamedInRoomUser extends InRoomUser {
-  'user_name': string | null
 }
 
 /**
@@ -39,9 +28,6 @@ let clients: {
  */
 async function sendUsersUpdatedEvent () {
   try {
-    // TODO
-    // できれば型エイリアス(type alias)をmodelsに書くようにして
-    // 呼び出す側では自動的に型が決まるようにしたい
     const users: NamedInRoomUser[] = await roomTable.listUsers()
     for (const user of users) {
       // TODO まだ名前をDBに登録していないので表示させられないが、将来的につけたい

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -37,7 +37,8 @@ async function sendUsersUpdatedEvent () {
       client.res.write(`event: usersUpdated\ndata: ${json}\n\n`, 'utf-8')
     }
   } catch (err) {
-    console.error('[!] Error', err)
+    // DBのエラーかもしれないしJSON.stringifyのエラーかもしれない
+    console.error('[!] Error:', err)
     // コネクションが(サーバー側から)閉じられた時にクライアント側ではEventSourceのerrorイベントが
     // 発火し、数秒後に再接続をトライしてくる。だからここは迷わずコネクションを切ってよし。
     // ただし何度もリトライされても困るのでクライアントには3回トライしたら止めるなど配慮してほしい。

--- a/app/models/accessLogsModel.ts
+++ b/app/models/accessLogsModel.ts
@@ -9,7 +9,7 @@ type AccessLog = {
   'exited_at': Date
 }
 
-async function createAccessLog (userId: number, enteredAt: string) {
+async function createAccessLog (userId: number, enteredAt: Date) {
   // INSERT すると [ResultSetHeader, undefined] が返ってくる
   await mysql.query(`INSERT INTO ${TABLENAME} (user_id, entered_at) VALUES (?, ?)`,
     [userId, enteredAt])

--- a/app/models/accessLogsModel.ts
+++ b/app/models/accessLogsModel.ts
@@ -43,7 +43,7 @@ async function listAccessLogs (
     return rows
   }
 
-  throw new Error('response from DB is malformed')
+  throw new Error('response from DB is not an array')
 }
 
 export { createAccessLog, getCountOfAccessLogs, listAccessLogs }

--- a/app/models/accessLogsModel.ts
+++ b/app/models/accessLogsModel.ts
@@ -3,6 +3,12 @@ import mysql from '../database/db'
 
 const TABLENAME = 'access_logs'
 
+type AccessLog = {
+  'user_id': number,
+  'entered_at': Date,
+  'exited_at': Date
+}
+
 async function createAccessLog (userId: number, enteredAt: string) {
   // INSERT すると [ResultSetHeader, undefined] が返ってくる
   await mysql.query(`INSERT INTO ${TABLENAME} (user_id, entered_at) VALUES (?, ?)`,

--- a/app/models/accessLogsModel.ts
+++ b/app/models/accessLogsModel.ts
@@ -4,53 +4,46 @@ import mysql from '../database/db'
 const TABLENAME = 'access_logs'
 
 async function createAccessLog (userId: number, enteredAt: string) {
-  try {
-    // INSERT すると [ResultSetHeader, undefined] が返ってくる
-    await mysql.query(`INSERT INTO ${TABLENAME} (user_id, entered_at) VALUES (?, ?)`,
-      [userId, enteredAt])
-    return [0, null]
-  } catch (err) {
-    return [null, err]
-  }
+  // INSERT すると [ResultSetHeader, undefined] が返ってくる
+  await mysql.query(`INSERT INTO ${TABLENAME} (user_id, entered_at) VALUES (?, ?)`,
+    [userId, enteredAt])
 }
 
 /**
  * access_logsの総行数を取得する
  */
 async function getCountOfAccessLogs () {
-  try {
-    // https://stackoverflow.com/a/11412968
-    const [rows, _] = await mysql.query(`SELECT count(*) AS logCount FROM ${TABLENAME}`)
+  // https://stackoverflow.com/a/11412968
+  const [rows, _] = await mysql.query(`SELECT count(*) AS logCount FROM ${TABLENAME}`)
 
-    if (Array.isArray(rows) && rows.length === 1) {
-      const row = rows[0]
-      if ('logCount' in row) {
-        return [row.logCount, null]
-      }
+  if (Array.isArray(rows) && rows.length === 1) {
+    const row = rows[0]
+    if ('logCount' in row) {
+      // SQLの仕様からしてcount()の返り値は整数なのでアサーションしても問題ない
+      return row.logCount as number
     }
-
-    return [null, 'response from DB is malformed']
-  } catch (error) {
-    return [null, error]
   }
+
+  throw new Error('response from DB is malformed')
 }
 
 async function listAccessLogs (
   since?: string, until?: string,
   order = 'DESC', limit = 100, offset = 0
 ) {
-  try {
-    const [rows, _] = await mysql.query(
-      `SELECT * FROM ${TABLENAME} ` +
-      "WHERE exited_at >= IFNULL(?, '1970-01-01') " +
-      'AND entered_at < IFNULL(?, ADDDATE(CURDATE(), 1)) ' +
-      `ORDER BY entered_at ${['ASC', 'DESC'].includes(order) ? order : 'DESC'} ` +
-      'LIMIT ? OFFSET ?',
-      [since, until, limit, offset])
-    return [rows, null]
-  } catch (err) {
-    return [null, err]
+  const [rows, _] = await mysql.query(
+    `SELECT * FROM ${TABLENAME} ` +
+    "WHERE exited_at >= IFNULL(?, '1970-01-01') " +
+    'AND entered_at < IFNULL(?, ADDDATE(CURDATE(), 1)) ' +
+    `ORDER BY entered_at ${['ASC', 'DESC'].includes(order) ? order : 'DESC'} ` +
+    'LIMIT ? OFFSET ?',
+    [since, until, limit, offset])
+
+  if (Array.isArray(rows)) {
+    return rows
   }
+
+  throw new Error('response from DB is malformed')
 }
 
 export { createAccessLog, getCountOfAccessLogs, listAccessLogs }

--- a/app/models/accessLogsModel.ts
+++ b/app/models/accessLogsModel.ts
@@ -46,7 +46,7 @@ async function listAccessLogs (
     [since, until, limit, offset])
 
   if (Array.isArray(rows)) {
-    return rows
+    return rows as AccessLog[]
   }
 
   throw new Error('response from DB is not an array')

--- a/app/models/inRoomUsersModel.ts
+++ b/app/models/inRoomUsersModel.ts
@@ -4,45 +4,41 @@ import mysql from '../database/db'
 const TABLENAME = 'in_room_users'
 
 async function createUser (userId: number) {
-  try {
-    // INSERT すると [ResultSetHeader, undefined] が返ってくる
-    await mysql.query(`INSERT INTO ${TABLENAME} (user_id) VALUES (?)`, userId)
-    return [0, null]
-  } catch (err) {
-    return [null, err]
-  }
+  // INSERT すると [ResultSetHeader, undefined] が返ってくる
+  await mysql.query(`INSERT INTO ${TABLENAME} (user_id) VALUES (?)`, userId)
 }
 
 async function deleteUser (userId: number) {
-  try {
-    // DELETE すると [ResultSetHeader, undefined] が返ってくる
-    await mysql.query(`DELETE FROM ${TABLENAME} WHERE user_id=?`, userId)
-    return [0, null]
-  } catch (err) {
-    return [null, err]
-  }
+  // DELETE すると [ResultSetHeader, undefined] が返ってくる
+  await mysql.query(`DELETE FROM ${TABLENAME} WHERE user_id=?`, userId)
 }
 
 async function getUser (userId: number) {
-  try {
-    const [row, _] = await mysql.query(`SELECT * FROM ${TABLENAME} WHERE user_id=?`, userId)
-    if (Array.isArray(row) && row.length !== 0) {
-      return [row[0], null]
-    } else {
-      return [null, null]
+  const [row, _] = await mysql.query(`SELECT * FROM ${TABLENAME} WHERE user_id=?`, userId)
+  if (Array.isArray(row) && row.length <= 1) {
+    if (row.length === 0) {
+      return null
+    // Array.isArray(row[0])はquery()が二次元配列を返すパターンがある。
+    // このクエリ内容ならそれはあり得ないのだが念のため。
+    // あり得ないので型アサーションで型を教えても問題ないといえばない。
+    } else if (Array.isArray(row[0])) {
+      throw new Error('response from DB is invalid')
+    // user_idはこのテーブルの主キーなので0でないとすれば必ず1なのだが一応。
+    } else if (row.length === 1) {
+      return row[0]
     }
-  } catch (err) {
-    return [null, err]
   }
+
+  throw new Error('response from DB is malformed')
 }
 
 async function listUsers () {
-  try {
-    const [row, _] = await mysql.query(`SELECT * FROM ${TABLENAME}`)
-    return [row, null]
-  } catch (err) {
-    return [null, err]
+  const [rows, _] = await mysql.query(`SELECT * FROM ${TABLENAME}`)
+  if (Array.isArray(rows)) {
+    return rows as []
   }
+
+  throw new Error('response from DB is not an array')
 }
 
 export { createUser, deleteUser, getUser, listUsers }

--- a/app/models/inRoomUsersModel.ts
+++ b/app/models/inRoomUsersModel.ts
@@ -3,7 +3,7 @@ import mysql from '../database/db'
 
 const TABLENAME = 'in_room_users'
 
-type InRoomUser = {
+export type InRoomUser = {
   'user_id': number,
   'entered_at': Date
 }

--- a/app/models/inRoomUsersModel.ts
+++ b/app/models/inRoomUsersModel.ts
@@ -29,7 +29,7 @@ async function getUser (userId: number) {
     }
   }
 
-  throw new Error('response from DB is malformed')
+  throw new Error('response from DB is invalid')
 }
 
 async function listUsers () {

--- a/app/models/inRoomUsersModel.ts
+++ b/app/models/inRoomUsersModel.ts
@@ -3,7 +3,7 @@ import mysql from '../database/db'
 
 const TABLENAME = 'in_room_users'
 
-type InRoomUsers = {
+type InRoomUser = {
   'user_id': number,
   'entered_at': Date
 }
@@ -30,7 +30,7 @@ async function getUser (userId: number) {
       throw new Error('response from DB is invalid')
     // user_idはこのテーブルの主キーなので0でないとすれば必ず1なのだが一応。
     } else if (row.length === 1) {
-      return row[0]
+      return row[0] as InRoomUser
     }
   }
 
@@ -40,7 +40,7 @@ async function getUser (userId: number) {
 async function listUsers () {
   const [rows, _] = await mysql.query(`SELECT * FROM ${TABLENAME}`)
   if (Array.isArray(rows)) {
-    return rows as []
+    return rows as InRoomUser[]
   }
 
   throw new Error('response from DB is not an array')

--- a/app/models/inRoomUsersModel.ts
+++ b/app/models/inRoomUsersModel.ts
@@ -3,6 +3,11 @@ import mysql from '../database/db'
 
 const TABLENAME = 'in_room_users'
 
+type InRoomUsers = {
+  'user_id': number,
+  'entered_at': Date
+}
+
 async function createUser (userId: number) {
   // INSERT すると [ResultSetHeader, undefined] が返ってくる
   await mysql.query(`INSERT INTO ${TABLENAME} (user_id) VALUES (?)`, userId)


### PR DESCRIPTION
Promiseにまつわるエラーハンドリングのやり方を修正したのとそれに合わせて型を作りました．

`models/`以下のファイルに書かれた関数は基本的に0番目に結果，1番目にあればエラーを含む配列を返すようになっていました．これを結果だけを返し，mysqlがエラーをthrowしても放置するように変更しました．

これらの関数はもとより全てasync functionなのでmysqlがエラーをthrowするとreject()に流れます．それを今まで生かしてなかったので，今回，呼び出し側の`controllers/`以下のファイルに書かれた関数に`try catch`を書いて例外処理をするように変更したというわけです．こうするとreturnに書かれるものが必然的にPromiseがfulfillされたときのものになり，エディタの補完が少し便利になります．

それからSQLのスキーマに対応するTSの型を作りました．`models/`側で返す前にSQLクエリを発行した結果をチェックした上でこの型で型アサーションして返すことで呼び出し側での補完が少し便利になります．

```typescript
// model側
type InRoomUser = {
  'user_id': number,
  'entered_at': Date
}
async function getUser (userId: number): Promise<InRoomUser> {}

// controller側
try {
  // 今までany[]だったものがInRoomUserになるので便利
  const user = await table.getUser(parseInt(req.params.user_id))
  //...以下略
} catch (err) {
  // rejectされたらここに来る
  console.error('[!] Error', err)
}
```

レビューよろしくお願いします．