### PR TITLE
config.yml.sampleからportが抜けていたのを修正

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -8,6 +8,7 @@ amsOptions:
 # mysqlに渡す接続情報
 dbOptions:
   host: "localhost"
+  port: 3306
   user: "username"
   password: "userpass"
   database: "dbnametoconnect"


### PR DESCRIPTION
config-yamlブランチでやる作業を一つ忘れていたのでやりました．
ba6ce0ffa281fc2e9763527158b701ca94b72994 でconfit.ts上はすべてのプロパティがrequiredになったのですが，sampleファイルでは必要なプロパティが1つ欠けていた(`port`が無かった)ので追加しました．