### PR TITLE
アクセスログの表示内容を変更

### DIFF
--- a/ams-backend.ts
+++ b/ams-backend.ts
@@ -36,7 +36,7 @@ function prepareMorgan () {
     }
   )
 
-  const formatStr = ':remote-addr - :remote-user [:localdate] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"'
+  const formatStr = ':remote-addr (fwd :req[x-forwarded-for]) [:localdate] ":method :url" :status :res[content-length] ":referrer" ":user-agent"'
 
   return morgan(formatStr, {
     stream: wStream


### PR DESCRIPTION
- x-forwarded-for を読んでプロキシ元のリモートアドレスを表示するようにした
- HTTPのバージョン表示を削除
- リモートユーザ名を削除(Basic, Digest認証を使わない限り表示されないため)

ログの例:
```
::ffff:172.19.0.1 (fwd 192.168.10.13) [2021-03-29T17:18:55+09:00] "GET /v1/users_updated_event" 200 - "http://192.168.10.12:3001/" "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1"
::ffff:172.19.0.1 (fwd -) [2021-03-29T17:19:38+09:00] "GET /" 200 55 "-" "curl/7.64.1"
::ffff:172.19.0.1 (fwd 127.0.0.1) [2021-03-29T17:19:45+09:00] "GET /v1/" 200 55 "-" "curl/7.64.1"
```
(1行目はフロントエンド経由の外部からのアクセス、2行目はローカルホストからバックエンドへの直接アクセス、3行目はローカルホストからフロントエンドの`/api`経由のアクセス)